### PR TITLE
Fixed Spotify plugin to manage magnets and open URIs and removed reachie...

### DIFF
--- a/plugins/giphy.js
+++ b/plugins/giphy.js
@@ -16,17 +16,13 @@ module.exports = (function(){
 
 			if (text.indexOf('giphy:') === 0 && text.length >= 5) {
 				var term = text.substr(6);
-				if(_.contains(['reacharound', 'reachie', 'reach-around'], term)) {
-					bot.say(to, 'http://ugcserver.com/betsie.gif');
-				} else {
-					randomGiphy(text.substr(6), function(err, url){
-						if (err){
-							bot.say(to, err);
-						}else{
-							bot.say(to, url);
-						}
-					});
-				}
+				randomGiphy(text.substr(6), function(err, url){
+					if (err){
+						bot.say(to, err);
+					}else{
+						bot.say(to, url);
+					}
+				});
 			}
 		});
 	};

--- a/plugins/spotify.js
+++ b/plugins/spotify.js
@@ -7,66 +7,101 @@ var spotifyApi = new SpotifyWebApi();
 
 module.exports = (function(){
 
-  var bot,
-	log,
-	conf;
+	var bot,
+		redis,
+		log,
+		conf;
 
-  return function init( _bot ){
-	bot = _bot;
-	log = bot.log;
-	conf = bot.conf;
+	return function init( _bot ){
+		bot = _bot;
+		log = bot.log;
+		conf = bot.conf;
 
-	bot.on( 'message', function( from, to, text ){
+		bot.on( 'message', function( from, to, text, message ){
 
-	  if (bot.isChannelPaused(to)) return;
+    	if (bot.isChannelPaused(to)) return;
 
-	  if (to === bot.botName) {
-		//they are talking to us in a private message, set to to be from
-		to = from;
-	  }
+      if (to === bot.botName) {
+				//they are talking to us in a private message, set to to be from
+				to = from;
+			}
 
-	  if (text.indexOf('spotify:') >= 0){
-		text = text.substring(text.indexOf('spotify:'));
-		var parts = text.trim().split(':');
+			if (text.indexOf('spotify:') >= 0){
+				text = text.substring(text.indexOf('spotify:'));
+				var parts = text.trim().split(':');
 
+				processSpotifyLink(parts, true);
+
+			} else if (text.indexOf('https://open.spotify.com/') >= 0){
+				text = text.replace('https://open.spotify.com/', 'spotify:');
+				text = text.replace('/', ':');
+				var parts = text.trim().split(':');
+
+				processSpotifyLink(parts, false);
+
+			}
+		});
+	};
+
+
+
+	function processSpotifyLink(parts, showlink) {
 		switch (parts[1]) {
-		  case 'track':
-			spotifyApi.getTrack(parts[2])
-			  .then(function(data) {
-				//console.log('Track data', data);
-				console.log('%s by %s ~ %s', data.name, data.artists[0].name, data.external_urls.spotify);
-				bot.say( '##geekonomics', 'Spotify track: ' + data.name + ' by ' + data.artists[0].name + ' ~ ' + data.external_urls.spotify );
-				bot.say( '#geekonomicsBot', 'Spotify track: ' + data.name + ' by ' + data.artists[0].name + ' ~ ' + data.external_urls.spotify );
-			  }, function(err) {
-				console.error(err);
-			  });
-			break;
-		  case 'artist':
-			spotifyApi.getArtist(parts[2])
-			  .then(function(data) {
-				//console.log('Artist information', data);
-				console.log('%s ~ %s', data.name, data.external_urls.spotify);
-				bot.say( '##geekonomics', 'Spotify artist: ' + data.name + ' ~ ' + data.external_urls.spotify );
-				bot.say( '#geekonomicsBot', 'Spotify artist: ' + data.name + ' ~ ' + data.external_urls.spotify );
-			  }, function(err) {
-				console.error(err);
-			  });
-			break;
-		  case 'album':
-			spotifyApi.getAlbum(parts[2])
-			  .then(function(data) {
-				//console.log('Album information', data);
-				console.log('%s by %s ~ %s', data.name, data.artists[0].name, data.external_urls.spotify);
-				bot.say( '##geekonomics', 'Spotify album: ' + data.name + ' by ' + data.artists[0].name + ' ~ ' + data.external_urls.spotify );
-				bot.say( '#geekonomicsBot', 'Spotify album: ' + data.name + ' by ' + data.artists[0].name + ' ~ ' + data.external_urls.spotify );
-			  }, function(err) {
-				console.error(err);
-			  });
-			break;
+			case 'track':
+				spotifyApi.getTrack(parts[2])
+					.then(function(data) {
+
+						console.log('%s by %s ~ %s', data.name, data.artists[0].name, data.external_urls.spotify);
+
+						var msg = 'Spotify track: ' + data.name + ' by ' + data.artists[0].name;
+						if(showlink) {
+							msg += ' ~ ' + data.external_urls.spotify;
+						}
+
+						bot.say( '##coldfusion', msg );
+						bot.say( '#zoidbox', msg );
+					}, function(err) {
+						console.error(err);
+					});
+				break;
+			case 'artist':
+				spotifyApi.getArtist(parts[2])
+					.then(function(data) {
+
+						console.log('%s ~ %s', data.name, data.external_urls.spotify);
+
+						var msg = 'Spotify artist: ' + data.name;
+						if(showlink) {
+							msg += ' ~ ' + data.external_urls.spotify;
+						}
+
+						bot.say( '##coldfusion', msg );
+						bot.say( '#zoidbox', msg );
+
+					}, function(err) {
+						console.error(err);
+					});
+				break;
+			case 'album':
+				spotifyApi.getAlbum(parts[2])
+					.then(function(data) {
+
+						console.log('%s by %s ~ %s', data.name, data.artists[0].name, data.external_urls.spotify);
+
+						var msg = 'Spotify album: ' + data.name + ' by ' + data.artists[0].name;
+						if(showlink) {
+							msg += ' ~ ' + data.external_urls.spotify;
+						}
+
+						bot.say( '##coldfusion', msg );
+						bot.say( '#zoidbox', msg );
+
+					}, function(err) {
+						console.error(err);
+					});
+				break;
 		}
-	  }
-	});
-  };
+	}
 
 
 }());


### PR DESCRIPTION
Fixed Spotify plugin to manage magnets and open URIs and removed reachie-stupidity

The Spotify plugin now manages both types of publicly available links to share and if it's a magnet URI provided the bot will also return the open.spotify.com link as well as artist / track names. Also fixed the channel names so it works with zoidbox and the cf channel.

Removed reachie stupidity because, well, it was stupid.